### PR TITLE
Add support for configuring the nunjucks template path of descriptions

### DIFF
--- a/lib/collections/ComponentsCollection.js
+++ b/lib/collections/ComponentsCollection.js
@@ -14,17 +14,26 @@
      * A collection of component models
      *
      * @class ComponentsCollection
+     * @param {Object} options  user override options passed to emo-gen
      * @constructor
      */
-    var ComponentsCollection = function() {
+    var ComponentsCollection = function(options) {
         /**
          * An object containing component
          * categories containing components
-         * 
+         *
          * @property componentsCollection.components
          * @default {}
          */
         this.components = {};
+
+        /* if user specified a template path to use when rendering the description
+        then configure a nunjucks environment with it. */
+        if (options && options.descriptionTmplPath) {
+            this.njkEnv = nunjucks.configure(options.descriptionTmplPath);
+        } else {
+            this.njkEnv = nunjucks;
+        }
     };
 
     var proto = ComponentsCollection.prototype;
@@ -49,7 +58,7 @@
     /**
      * Process the list of provided components;
      * add each passing component to the components collection
-     * 
+     *
      * @method componentsCollection.process
      * @param {Array} list  list of raw component data
      */
@@ -58,7 +67,7 @@
 
         components
             .filter(this.isValid)
-            .map(this.map)
+            .map(this.map.bind(this))
             .sort(this.sortByCategory)
             .forEach(function(component) {
                 this.add(component);
@@ -80,7 +89,7 @@
         var componentModel = new ComponentModel().fromJSON({
             name: data.name,
             category: data.category,
-            description: marked(nunjucks.renderString(fileExists(file) ? readFile(file) : description)),
+            description: marked(this.njkEnv.renderString(fileExists(file) ? readFile(file) : description)),
             path: path.join(data.category, data.filename || data.name + '.html')
         }).toJSON();
 

--- a/lib/components/StyleGuideGenerator.js
+++ b/lib/components/StyleGuideGenerator.js
@@ -34,7 +34,7 @@
         /**
          * @property styleGuideGenerator.componentsCollection
          */
-        this.componentsCollection = new ComponentsCollection();
+        this.componentsCollection = new ComponentsCollection(this.options);
 
         /**
          * @property styleGuideGenerator.viewsCollection
@@ -73,7 +73,7 @@
 
     /**
      * Initialize the styleGuideGenerator
-     * 
+     *
      * @method styleGuideGenerator.init
      */
     proto.init = function() {
@@ -88,7 +88,7 @@
     /**
      * Place the style guide src files in their
      * working directory (specified by this.options.src)
-     * 
+     *
      * @method styleGuideGenerator.place
      */
     proto.place = function() {
@@ -105,7 +105,7 @@
     /**
      * Copy all of the specified files
      * to their specified destinations
-     * 
+     *
      * @method styleGuideGenerator.copy
      * @param {Array} files  a list of src-dest file mappings
      */
@@ -120,7 +120,7 @@
     /**
      * Scrape the provided files
      * for component documentation
-     * 
+     *
      * @method styleGuideGenerator.scrape
      * @param {Array} files  files to scrape
      */
@@ -139,7 +139,7 @@
 
     /**
      * Build the style guide
-     * 
+     *
      * @method styleGuideGenerator.build
      * @param {Array} componentFiles  a list of component files/glob patterns
      * @param {String} viewDir  the path to the views directory
@@ -174,7 +174,7 @@
 
     /**
      * Build the index.html page
-     * 
+     *
      * @method styleGuideGenerator.buildIndex
      * @return {Object} a promise
      */
@@ -193,7 +193,7 @@
 
     /**
      * Build out the components
-     * 
+     *
      * @method styleGuideGenerator.buildComponents
      * @return {Object} a promise
      */
@@ -225,7 +225,7 @@
 
     /**
      * Build out the views
-     * 
+     *
      * @method styleGuideGenerator.buildViews
      * @return {Object} a promise
      */


### PR DESCRIPTION
TLDR; Adds support for accessing templates outside of the directory being used for the styleguide.

When writing descriptions it would be nice to be able to access templates that live outside of the styleguide directory. This PR adds support for specifying a path to use when compiling the descriptions.

Imagine the following file structure:

```
| -- src
|  |-- assets
|  |  |-- somewhere under here a btn.md to document _btn.scss
|  |-- includes
|  |  |-- macros.njk
|  |-- styleguide
|  |  |-- all the styleguide stuff templates and assets.
```

Currently it's not possible to import `macros.njk` from `btn.md` because they are in adjacent folders and you can't use relative paths with `nunjucks.renderString`. This is assuming that the styleguide directory is being used as the options.path.src and you are not wanting to use emo-gen to compile the static pages of the site.

For the structure above this PR would allow you to specify the `src` path and then import the macros like 

```
{% import 'includes/macros.njk' as macros %}
```

This PR is currently just at a rough proof of concept stage. There are other methods of providing the same functionality that may be better. If there is interest in this PR I can clean it up and add documentation.
